### PR TITLE
Log webhook events

### DIFF
--- a/demo/demo/tests/test_api.py
+++ b/demo/demo/tests/test_api.py
@@ -112,9 +112,9 @@ def test_subscribe(client, user_client, plan, now):
 
 
 def test__webhook_logging(client, caplog):
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.INFO):
         client.post('/api/webhook/dummy/', {'webhook-key': 'webhook-value'})
-    assert re.search(r"ARCHIVE .+? Webhook at http://testserver/api/webhook/dummy/ received payload {'webhook-key': 'webhook-value'}", caplog.text)
+    assert re.search(r"INFO .+? Webhook at http://testserver/api/webhook/dummy/ received payload {'webhook-key': 'webhook-value'}", caplog.text)
 
 
 def test_resources(user_client, subscription, resource, quota, now):

--- a/subscriptions/api/views.py
+++ b/subscriptions/api/views.py
@@ -1,4 +1,3 @@
-from logging import getLogger
 from typing import Type
 
 from django.conf import settings
@@ -8,16 +7,18 @@ from rest_framework.generics import GenericAPIView, ListAPIView, RetrieveAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.schemas.openapi import AutoSchema
+
 from subscriptions.functions import get_remaining_amount
 
 from ..defaults import DEFAULT_SUBSCRIPTIONS_SUCCESS_URL
 from ..exceptions import PaymentError, SubscriptionError
+from ..logging import logging
 from ..models import Plan, Subscription, SubscriptionPayment
 from ..providers import Provider, get_provider, get_providers
 from ..validators import get_validators
 from .serializers import PaymentProviderListSerializer, PlanSerializer, ResourcesSerializer, SubscriptionPaymentSerializer, SubscriptionSelectSerializer, SubscriptionSerializer, WebhookSerializer
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 class PlanListView(ListAPIView):
@@ -113,6 +114,7 @@ class PaymentWebhookView(GenericAPIView):
         payload = request.data
         if isinstance(payload, QueryDict):
             payload = payload.dict()
+        log.archive('Webhook at %s received payload %s', request.build_absolute_uri(), payload)
         return self.provider.webhook(request=request, payload=payload)
 
 

--- a/subscriptions/api/views.py
+++ b/subscriptions/api/views.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Type
 
 from django.conf import settings
@@ -12,7 +13,6 @@ from subscriptions.functions import get_remaining_amount
 
 from ..defaults import DEFAULT_SUBSCRIPTIONS_SUCCESS_URL
 from ..exceptions import PaymentError, SubscriptionError
-from ..logging import logging
 from ..models import Plan, Subscription, SubscriptionPayment
 from ..providers import Provider, get_provider, get_providers
 from ..validators import get_validators
@@ -114,7 +114,7 @@ class PaymentWebhookView(GenericAPIView):
         payload = request.data
         if isinstance(payload, QueryDict):
             payload = payload.dict()
-        log.archive('Webhook at %s received payload %s', request.build_absolute_uri(), payload)
+        log.info('Webhook at %s received payload %s', request.build_absolute_uri(), payload)
         return self.provider.webhook(request=request, payload=payload)
 
 

--- a/subscriptions/logging.py
+++ b/subscriptions/logging.py
@@ -1,0 +1,9 @@
+import logging
+from functools import partial, partialmethod
+
+# add a high log level (higher than ERROR) which will store
+# information helpful for backtracing
+logging.ARCHIVE = logging.ERROR + 1
+logging.addLevelName(logging.ARCHIVE, 'ARCHIVE')
+logging.Logger.archive = partialmethod(logging.Logger.log, logging.ARCHIVE)
+logging.archive = partial(logging.log, logging.ARCHIVE)

--- a/subscriptions/logging.py
+++ b/subscriptions/logging.py
@@ -1,9 +1,0 @@
-import logging
-from functools import partial, partialmethod
-
-# add a high log level (higher than ERROR) which will store
-# information helpful for backtracing
-logging.ARCHIVE = logging.ERROR + 1
-logging.addLevelName(logging.ARCHIVE, 'ARCHIVE')
-logging.Logger.archive = partialmethod(logging.Logger.log, logging.ARCHIVE)
-logging.archive = partial(logging.log, logging.ARCHIVE)


### PR DESCRIPTION
This is a quick fix for having all webhook events in our logs for debugging.

However, the downside of using logs for storing this information is that logs may be "disabled" (by setting higher log levels). So I added custom log level (ARCHIVE) which is higher that ERROR.