### PR TITLE
Fix alias support in migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.4] - 2023-07-04
+
+### Fixed
+
+- Fix migrations if non-default database is used
+
+## [1.0.3] - 2023-07-01
+
+### Fixed
+
+- Fix Paddle double-charge

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-subscriptions-rt
-version = 1.0.3
+version = 1.0.4
 author = Aleksandr Goncharov
 author_email = aleksandr.goncharov@reef.pl
 description = Subscriptions and payments for your django app

--- a/subscriptions/migrations/0012_subscription_uid_subscriptionpayment_uid_and_more.py
+++ b/subscriptions/migrations/0012_subscription_uid_subscriptionpayment_uid_and_more.py
@@ -6,9 +6,10 @@ from uuid import uuid4
 
 
 def populate_uuids(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
     for model in {'Subscription', 'SubscriptionPayment', 'SubscriptionPaymentRefund'}:
         cls = apps.get_model('subscriptions', model)
-        for instance in cls.objects.all():
+        for instance in cls.objects.using(db_alias).all():
             instance.uid = uuid4()
             instance.save()
 

--- a/subscriptions/migrations/0015_auto_20220728_1920.py
+++ b/subscriptions/migrations/0015_auto_20220728_1920.py
@@ -4,18 +4,19 @@ from django.db import migrations
 
 
 def fill_in_uid_fks(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
     SubscriptionPayment = apps.get_model('subscriptions', 'SubscriptionPayment')
-    for payment in SubscriptionPayment.objects.exclude(subscription=None):
+    for payment in SubscriptionPayment.objects.using(db_alias).exclude(subscription=None):
         payment.subscription_uid = payment.subscription
         payment.save()
 
     SubscriptionPaymentRefund = apps.get_model('subscriptions', 'SubscriptionPaymentRefund')
-    for refund in SubscriptionPaymentRefund.objects.all():
+    for refund in SubscriptionPaymentRefund.objects.using(db_alias).all():
         refund.original_payment_uid = refund.original_payment.uid
         refund.save()
 
     Tax = apps.get_model('subscriptions', 'Tax')
-    for tax in Tax.objects.all():
+    for tax in Tax.objects.using(db_alias).all():
         tax.subscription_payment_uid = tax.subscription_payment.uid
         tax.save()
 

--- a/subscriptions/migrations/0027_auto_20221109_1525.py
+++ b/subscriptions/migrations/0027_auto_20221109_1525.py
@@ -11,7 +11,8 @@ from logging import getLogger
 log = getLogger(__name__)
 
 
-def remove_apple_in_app_subscription_duplicates(apps, scheme_editor):
+def remove_apple_in_app_subscription_duplicates(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
     subscription_payment_model = apps.get_model('subscriptions', 'SubscriptionPayment')
 
     # We need to find all the entries that share the same provider_transaction_id for provider_codename `apple_in_app`.
@@ -21,7 +22,7 @@ def remove_apple_in_app_subscription_duplicates(apps, scheme_editor):
     # Thus, we need to gather all subscription payment objects and determine how many attached payments has each
     # subscription.
 
-    all_entries = subscription_payment_model.objects \
+    all_entries = subscription_payment_model.objects.using(db_alias) \
         .filter(provider_codename='apple_in_app') \
         .select_related('subscription', 'plan')
 


### PR DESCRIPTION
https://docs.djangoproject.com/en/4.2/ref/migration-operations/#runpython
> RunPython does not magically alter the connection of the models for you; any model methods you call will go to the default database unless you give them the current database alias (available from schema_editor.connection.alias, where schema_editor is the second argument to your function).