### PR TITLE
Add `update_fields` to `subscription.save()` calls to avoid double payments

### DIFF
--- a/subscriptions/api/views.py
+++ b/subscriptions/api/views.py
@@ -88,7 +88,7 @@ class SubscriptionView(DestroyAPIView):
                 raise BadRequest(detail='Cancellation endpoint is not allowed for this provider')
 
         instance.auto_prolong = False
-        instance.save()
+        instance.save(update_fields=['auto_prolong'])
 
 
 class SubscriptionSelectView(GenericAPIView):
@@ -139,7 +139,7 @@ class SubscriptionSelectView(GenericAPIView):
                 now_ = now()
                 for subscription in exc.subscriptions:
                     subscription.end = now()
-                    subscription.save()
+                    subscription.save(update_fields=['end'])
             except SubscriptionError as exc:
                 raise PermissionDenied(detail=str(exc)) from exc
 

--- a/subscriptions/providers/apple_in_app/__init__.py
+++ b/subscriptions/providers/apple_in_app/__init__.py
@@ -186,7 +186,7 @@ class AppleInAppProvider(Provider):
                 )
                 if was_created:
                     payment.subscription.auto_prolong = False
-                    payment.subscription.save()
+                    payment.subscription.save(update_fields=['auto_prolong'])
             except SubscriptionPayment.MultipleObjectsReturned:
                 # This is left as a countermeasure in case the deduplication fails or the code is still "not good enough"
                 # and generates duplicates. It allows us to read a warning from sentry instead of rushing another fix.
@@ -273,7 +273,7 @@ class AppleInAppProvider(Provider):
             current_plan = self._get_plan_for_product_id(transaction_info.product_id)
             # Stopping old subscription, so that the user won't benefit from both of them.
             subscription.end = timezone.now()
-            subscription.save()
+            subscription.save(update_fields=['end'])
             # New subscription will be created with a new payment object.
             subscription = None
 
@@ -311,7 +311,7 @@ class AppleInAppProvider(Provider):
         # Ensuring that subscription ends earlier before making the payment end earlier.
         now = timezone.now()
         latest_payment.subscription.end = now
-        latest_payment.subscription.save()
+        latest_payment.subscription.save(update_fields=['end'])
         latest_payment.subscription_end = now
 
         latest_payment.save()
@@ -339,7 +339,7 @@ class AppleInAppProvider(Provider):
         assert refunded_payment, f'Refund received for {transaction_info=} where no payments exist.'
 
         refunded_payment.subscription.end = transaction_info.revocation_date
-        refunded_payment.subscription.save()
+        refunded_payment.subscription.save(update_fields=['end'])
         refunded_payment.subscription_end = transaction_info.revocation_date
         refunded_payment.status = SubscriptionPayment.Status.CANCELLED
 

--- a/subscriptions/providers/google_in_app/__init__.py
+++ b/subscriptions/providers/google_in_app/__init__.py
@@ -278,7 +278,7 @@ class GoogleInAppProvider(Provider):
             subscription = latest_payment.subscription
             if subscription.end > now_:
                 subscription.end = now_
-                subscription.save()
+                subscription.save(update_fields=['end'])
 
     def get_user_by_token(self, token: str) -> AbstractBaseUser | None:
         with suppress(SubscriptionPayment.DoesNotExist):
@@ -419,7 +419,7 @@ class GoogleInAppProvider(Provider):
                 subscription = last_payment.subscription
                 subscription.end = max(subscription.end, purchase_end)
                 # subscription.auto_prolong = True  # TODO: set this when it does not affect offline charges
-                subscription.save()
+                subscription.save(update_fields=['end'])
 
             elif event == GoogleSubscriptionNotificationType.RENEWED:
                 # TODO: handle case when subscription is resumed from a pause
@@ -434,7 +434,7 @@ class GoogleInAppProvider(Provider):
 
                 subscription = last_payment.subscription
                 # subscription.auto_prolong = True  # TODO: set this when it does not affect offline charges
-                subscription.save()
+                subscription.save(update_fields=['auto_prolong'])
 
             elif event == GoogleSubscriptionNotificationType.CANCELED:
                 last_payment = self.get_last_payment(purchase_token)
@@ -442,7 +442,7 @@ class GoogleInAppProvider(Provider):
 
                 subscription.end = purchase_end
                 subscription.auto_prolong = False
-                subscription.save()
+                subscription.save(update_fields=['end', 'auto_prolong'])
 
                 if last_payment.subscription_end > subscription.end:
                     last_payment.subscription_end = subscription.end
@@ -474,14 +474,14 @@ class GoogleInAppProvider(Provider):
 
                 subscription.end = now()
                 subscription.auto_prolong = False
-                subscription.save()
+                subscription.save(update_fields=['end', 'auto_prolong'])
 
             elif event == GoogleSubscriptionNotificationType.EXPIRED:
                 last_payment = self.get_last_payment(purchase_token)
                 subscription = last_payment.subscription
                 subscription.end = purchase_end
                 subscription.auto_prolong = False
-                subscription.save()
+                subscription.save(update_fields=['end', 'auto_prolong'])
 
             else:
                 raise ValueError('Unsupported notification type %s', event)
@@ -494,7 +494,7 @@ class GoogleInAppProvider(Provider):
                 subscription.auto_prolong
             ):
                 subscription.auto_prolong = False
-                subscription.save()
+                subscription.save(update_fields=['auto_prolong'])
 
             if linked_token:
                 assert purchase_token != linked_token

--- a/subscriptions/signals.py
+++ b/subscriptions/signals.py
@@ -63,7 +63,7 @@ with suppress(ImportError):
         for subscription in future_subscriptions:
             if new_value:
                 subscription.plan_id = new_value
-                subscription.save()
+                subscription.save(update_fields=['plan_id'])
             else:
                 subscription.delete()
 
@@ -78,7 +78,7 @@ with suppress(ImportError):
             end = subscription.end
 
             subscription.end = now_
-            subscription.save()
+            subscription.save(update_fields=['end'])
 
             if new_value:
                 subscription.pk = None


### PR DESCRIPTION
The duplicate payment problem occurs when `subscription.end` is being reset after updating. Looking at the logs (from @agoncharov-reef):

```
DEBUG 2023-09-07 22:11:29,000 subscriptions.tasks Real subscription value after successful offline charge: 7a59a87b spencer.lee.sfc@gmail.com 1 Pro, 2023-08-06 17:33:30+00:00 - 2023-10-06 17:33:30+00:00
DEBUG 2023-09-07 22:11:29,110 subscriptions.tasks Real subscription value after all tasks excution: 7a59a87b spencer.lee.sfc@gmail.com 1 Pro, 2023-08-06 17:33:30+00:00 - 2023-09-06 17:33:30.166616+00:00
```

The first log line is from inside the atomic block, the second line is from outside the atomic block.

I think the following scenario could be causing this problem:

```
Some operation that updates Subscription

          read Subscription
         /
        /            try to save, but blocked on FOR UPDATE lock
       /            /
      /            /            unblocked and completes save
     /            /            /
----*-----*======*========*---*----
           \               \
            \               release lock after task completes
             \
              locks subscriptions with FOR UPDATE

Task: charge_recurring_subscriptions
```

The order may be different, but if some operation reads Subscription before `charge_recurring_subscriptions` task's atomic block exits, it will read the old value of subscription. So, saving overwrites the updated values from the task.

I am suspecting this scenario because:
- the end time is being changed right after exiting the atomic block of `_charge_recurring_subscription` (the logs are only 111ms apart)
- the task does not touch db after exiting the atomic block

I have added `update_fields` flag for `Subscription.save()` calls. This will reduce the the surface area where this problem may occur (but will not solve it completely). The surface area is reduced to places where `subscription.start` and/or `subscription.end` is being updated.

## TODO

- [ ] Should we use `select_for_update` at all the places where we need to update `subscription.start` and/or `subscription.end` for synchronization?
    - [ ] If yes, should we `skip_locked=True` in the task? (how often is the task run?)

P.S: Concurrency is hard :')